### PR TITLE
Multipage animations bugfixes

### DIFF
--- a/sparklemotion/.gitignore
+++ b/sparklemotion/.gitignore
@@ -1,1 +1,3 @@
 /build
+/gradle
+/gradlew

--- a/sparklemotion/src/main/java/com/ifttt/sparklemotion/Animation.java
+++ b/sparklemotion/src/main/java/com/ifttt/sparklemotion/Animation.java
@@ -70,8 +70,12 @@ public abstract class Animation {
                 offset -= pageStart;
             }
 
-            int pageOfAnimation = page >= 0 && page <= pageEnd? page - pageStart : 0;
-            offset = (offset + pageOfAnimation) / mFractionAdjustment;
+            int pageOfAnimation = page > pageStart && page <= pageEnd
+                    ? page - pageStart
+                    : 0;
+
+            if (offset != 1) //case if we get the rescue frame
+                offset = (offset + pageOfAnimation) / mFractionAdjustment;
         }
 
         if (offset < -1) {

--- a/sparklemotion/src/main/java/com/ifttt/sparklemotion/Animation.java
+++ b/sparklemotion/src/main/java/com/ifttt/sparklemotion/Animation.java
@@ -33,7 +33,7 @@ public abstract class Animation {
     /**
      * Base constructor of the class, accepting common information about the animation to this
      * instance.
-     *
+     * <p/>
      * For animations that will run on multiple pages, the progress of the animation will be evenly split
      * across the pages. For ViewPager View animation, it might not be necessary to run such animation, as the View
      * will be invisible once the page is scrolled off-screen.
@@ -58,8 +58,9 @@ public abstract class Animation {
      * @param offset        Fraction of the ViewPager scrolling, this is also the progression of the
      *                      animation.
      * @param offsetInPixel Page width offset.
+     * @param page          Page inside of ViewPager
      */
-    void animate(View v, float offset, float offsetInPixel) {
+    void animate(View v, float offset, float offsetInPixel, int page) {
         if (mInterpolator != null) {
             offset = mInterpolator.getInterpolation(offset);
         }
@@ -69,7 +70,8 @@ public abstract class Animation {
                 offset -= pageStart;
             }
 
-            offset = offset / mFractionAdjustment;
+            int pageOfAnimation = page >= 0 && page <= pageEnd? page - pageStart : 0;
+            offset = (offset + pageOfAnimation) / mFractionAdjustment;
         }
 
         if (offset < -1) {
@@ -92,7 +94,6 @@ public abstract class Animation {
      * to the left of the window, and [0, 1] means the page is currently scrolling to the right of
      * the window.
      *
-     *
      * @param v             View being animated.
      * @param offset        Fraction of the ViewPager scrolling, this is also the progression of
      *                      the
@@ -105,7 +106,7 @@ public abstract class Animation {
     /**
      * Called when the animation is running when the View is off screen and is to the left of the
      * current screen.
-     *
+     * <p/>
      * This method is called only for Views inside ViewPager.
      *
      * @param v             View being animated.
@@ -121,7 +122,7 @@ public abstract class Animation {
     /**
      * Called when the animation is running when the View is off screen and is to the right of the
      * current screen.
-     *
+     * <p/>
      * This method is called only for Views inside ViewPager.
      *
      * @param v             View being animated.

--- a/sparklemotion/src/main/java/com/ifttt/sparklemotion/SparkleAnimationPresenter.java
+++ b/sparklemotion/src/main/java/com/ifttt/sparklemotion/SparkleAnimationPresenter.java
@@ -2,6 +2,7 @@ package com.ifttt.sparklemotion;
 
 import android.support.v4.util.SimpleArrayMap;
 import android.view.View;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +46,7 @@ final class SparkleAnimationPresenter {
     /**
      * Add animations to the target View. The View's id is used as key.
      *
-     * @param id Id of the target View.
+     * @param id         Id of the target View.
      * @param animations Animations to be associated to this View.
      */
     public void addAnimation(int id, Animation... animations) {
@@ -63,7 +64,7 @@ final class SparkleAnimationPresenter {
     /**
      * Add animations to the target {@link Decor}.
      *
-     * @param decor Target Decor.
+     * @param decor      Target Decor.
      * @param animations Animations to be associated to this Decor.
      */
     public void addAnimation(Decor decor, Animation... animations) {
@@ -81,8 +82,8 @@ final class SparkleAnimationPresenter {
      * Run the animations based on the View animations saved within the presenter and the offset of
      * the scrolling.
      *
-     * @param parent Current page View of the ViewPager.
-     * @param offset Scrolling offset of the ViewPager.
+     * @param parent        Current page View of the ViewPager.
+     * @param offset        Scrolling offset of the ViewPager.
      * @param offsetInPixel Scrolling offset in pixels based on the page View.
      */
     void presentAnimations(View parent, float offset, float offsetInPixel) {
@@ -109,7 +110,7 @@ final class SparkleAnimationPresenter {
                     continue;
                 }
 
-                animation.animate(viewToAnimate, offset, offsetInPixel);
+                animation.animate(viewToAnimate, offset, offsetInPixel, -1);
             }
         }
     }
@@ -119,7 +120,7 @@ final class SparkleAnimationPresenter {
      * of the scrolling.
      *
      * @param position Position of the current page.
-     * @param offset Offset of the ViewPager scrolling.
+     * @param offset   Offset of the ViewPager scrolling.
      */
     void presentDecorAnimations(int position, float offset) {
         // Animate all decor or other View animations.
@@ -138,15 +139,15 @@ final class SparkleAnimationPresenter {
                 if (!animation.shouldAnimate(position)) {
                     // Add a rescue frame to the animation if the page is scrolled really fast.
                     if (mPreviousPosition < position && animation.pageEnd < position) {
-                        animation.animate(decor.contentView, 1, 0);
+                        animation.animate(decor.contentView, 1, 0, position);
                     } else if (mPreviousPosition > position && animation.pageStart > position) {
-                        animation.animate(decor.contentView, 0, 0);
+                        animation.animate(decor.contentView, 0, 0, position);
                     }
 
                     continue;
                 }
 
-                animation.animate(decor.contentView, offset, 0);
+                animation.animate(decor.contentView, offset, 0, position);
             }
         }
 


### PR DESCRIPTION
The animations that were supposed to run on multiple pages were not working properly. I believe I fixed the problem. 

Error bug description: 
I tried to run animation on few pages, let's say Page.pageRange(1,3). On each page offset of the animation were going from 0 to 1, and then back to 0. 
What I would expect of such animation that on 1st page offset would go from 0 to 0.33, on 2nd page from 0.33 to 0.66 and on 3rd page from 0.66 to 1.0. Now it works like this. 