### PR TITLE
removed private member access between inner and outer classes

### DIFF
--- a/demo/src/main/java/com/ifttt/sparklemotiondemo/SparkleDemoActivity.java
+++ b/demo/src/main/java/com/ifttt/sparklemotiondemo/SparkleDemoActivity.java
@@ -194,6 +194,9 @@ public final class SparkleDemoActivity extends Activity {
 
     private static class PagerAdapter extends ViewPagerAdapter {
 
+        PagerAdapter() {
+        }
+
         @Override
         protected View getView(int position, ViewGroup container) {
             switch (position) {

--- a/sparklemotion/src/main/java/com/ifttt/sparklemotion/Decor.java
+++ b/sparklemotion/src/main/java/com/ifttt/sparklemotion/Decor.java
@@ -50,8 +50,8 @@ public class Decor {
      */
     final boolean withLayer;
 
-    private Decor(@NonNull View contentView, @NonNull Page page, boolean layoutBehind, Animation slideInAnimation,
-            Animation slideOutAnimation, boolean withLayer) {
+    Decor(@NonNull View contentView, @NonNull Page page, boolean layoutBehind, Animation slideInAnimation,
+          Animation slideOutAnimation, boolean withLayer) {
         this.contentView = contentView;
         this.startPage = page.start;
         this.endPage = page.end;

--- a/sparklemotion/src/main/java/com/ifttt/sparklemotion/Decor.java
+++ b/sparklemotion/src/main/java/com/ifttt/sparklemotion/Decor.java
@@ -50,7 +50,7 @@ public class Decor {
      */
     final boolean withLayer;
 
-    Decor(@NonNull View contentView, @NonNull Page page, boolean layoutBehind, Animation slideInAnimation,
+    private Decor(@NonNull View contentView, @NonNull Page page, boolean layoutBehind, Animation slideInAnimation,
           Animation slideOutAnimation, boolean withLayer) {
         this.contentView = contentView;
         this.startPage = page.start;

--- a/sparklemotion/src/main/java/com/ifttt/sparklemotion/SlideInAnimation.java
+++ b/sparklemotion/src/main/java/com/ifttt/sparklemotion/SlideInAnimation.java
@@ -16,12 +16,12 @@ final class SlideInAnimation extends Animation {
     /**
      * Distance of the View to slide out of the screen.
      */
-    private float mDistance;
+    float mDistance;
 
     /**
      * Translation X of the View before running this animation.
      */
-    private float mOriginalTranslationX;
+    float mOriginalTranslationX;
 
     public SlideInAnimation(@NonNull Page page) {
         super(page);

--- a/sparklemotion/src/main/java/com/ifttt/sparklemotion/SlideOutAnimation.java
+++ b/sparklemotion/src/main/java/com/ifttt/sparklemotion/SlideOutAnimation.java
@@ -15,12 +15,12 @@ final class SlideOutAnimation extends Animation {
     /**
      * Distance of the View to slide out of the screen.
      */
-    private float mDistance;
+    float mDistance;
 
     /**
      * Translation X of the View before running this animation.
      */
-    private float mOriginalTranslationX;
+    float mOriginalTranslationX;
 
     public SlideOutAnimation(Page page) {
         super(page);


### PR DESCRIPTION
Private member access between inner and outer classes causes synthetic accessor methods to be created on compile. These methods are counted against the dex limit.  By making these variables package local it remedies this issue.

Reference:
https://realm.io/news/360andev-jake-wharton-java-hidden-costs-android/

Awesome library, btw.  I am learning a ton from it