### PR TITLE
Mark project as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Deprecated
+This project is not being developed. Feel free to fork!
+<br/>
+<br/>
+<br/>
+
 [![Open Source at IFTTT](http://ifttt.github.io/images/open-source-ifttt.svg)](http://ifttt.github.io)
 
 ![Sparkle Motion](./art/sparklemotion-title.png)


### PR DESCRIPTION
The description should probably be prefixed with "Deprecated" as well.